### PR TITLE
Implement daily psalm pair pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Pairwise similarity and alternative sequencing of the Psalms, with cross‑tradi
 
 It walks through every pair of Psalms and asks the following question:
 
-	Consider Psalm X and Psalm Y (reproduced below). What arguments 
-	could you make to justify that Psalm Y follows on from Psalm X?
-	Consider stylistic similarities, similarities of vocab or ideas,
-	connections to sequences of events common in ancient Israel life
-	mythology or history.
+        Consider Psalm X and Psalm Y (reproduced below). What arguments
+        could you make to justify that Psalm Y follows on from Psalm X?
+        Consider stylistic similarities, similarities of vocab or ideas,
+        connections to sequences of events common in ancient Israel life
+        mythology or history.
 
 Having done that, a separate process then rates the arguments on a scale
 of 0 (very weak) to 10 (very strong).
@@ -22,3 +22,21 @@ Remember to cite Tanach:
 Unicode/XML Leningrad Codex: UXLC 2.3 (27.4),
 Tanach.us Inc., West Redding, CT, USA, April 2025.
 
+
+## Running locally
+
+The daily cron entry runs `cronscript.sh`, which will:
+
+1. Pull the latest code
+2. Generate and store a configurable number of Psalm pair arguments
+3. Evaluate pending arguments
+4. Rebuild the status website and deploy it to the production host
+
+Useful environment variables:
+
+- `PAIRS_PER_DAY` – number of new arguments to request (default 50)
+- `EVALS_PER_DAY` – number of evaluations to perform (default 50)
+- `SITE_DIR` – output directory for the generated website (default `site`)
+- `REMOTE_TARGET` – `scp` destination for deployment; leave blank to skip copying
+
+The scripts expect an OpenAI API key at `~/.openai.key`.

--- a/cronscript.sh
+++ b/cronscript.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
+set -euo pipefail
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
-git pull -q
+export UV_PROJECT_ENVIRONMENT=$(pwd)/.venv
+
+if command -v git >/dev/null 2>&1; then
+  git pull -q
+fi
+
+PAIRS_PER_DAY=${PAIRS_PER_DAY:-50}
+EVALS_PER_DAY=${EVALS_PER_DAY:-50}
+SITE_DIR=${SITE_DIR:-site}
+REMOTE_TARGET=${REMOTE_TARGET:-"merah.cassia.ifost.org.au:/var/www/vhosts/psalm-pairs.symmachus.org/htdocs/"}
+
+uv run psalm_pairs/generate_pairs.py --limit "$PAIRS_PER_DAY"
+uv run psalm_pairs/evaluate_pairs.py --limit "$EVALS_PER_DAY"
+uv run psalm_pairs/website.py --output "$SITE_DIR"
+
+if [ -n "$REMOTE_TARGET" ]; then
+  scp -r "$SITE_DIR"/* "$REMOTE_TARGET"
+fi

--- a/psalm_pairs/__init__.py
+++ b/psalm_pairs/__init__.py
@@ -1,0 +1,12 @@
+"""Core package for Psalm pair generation and evaluation."""
+
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parent
+PROJECT_ROOT = PACKAGE_ROOT.parent
+DATA_DIR = PROJECT_ROOT / "data"
+DATA_DIR.mkdir(exist_ok=True)
+
+DB_PATH = (DATA_DIR / "psalm_pairs.sqlite3").resolve()
+
+__all__ = ["DB_PATH", "DATA_DIR", "PACKAGE_ROOT", "PROJECT_ROOT"]

--- a/psalm_pairs/db.py
+++ b/psalm_pairs/db.py
@@ -1,0 +1,188 @@
+"""SQLite helpers for tracking Psalm pair generation and evaluations."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator, Optional
+
+from . import DB_PATH
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS pair_arguments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    psalm_x INTEGER NOT NULL,
+    psalm_y INTEGER NOT NULL,
+    prompt TEXT NOT NULL,
+    response_text TEXT NOT NULL,
+    response_json TEXT NOT NULL,
+    model TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    UNIQUE (psalm_x, psalm_y)
+);
+
+CREATE TABLE IF NOT EXISTS pair_evaluations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    pair_id INTEGER NOT NULL,
+    score REAL NOT NULL,
+    justification TEXT NOT NULL,
+    evaluator_model TEXT NOT NULL,
+    evaluation_json TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    FOREIGN KEY(pair_id) REFERENCES pair_arguments(id) ON DELETE CASCADE,
+    UNIQUE (pair_id)
+);
+"""
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(SCHEMA)
+    conn.commit()
+
+
+def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
+    path = Path(db_path or DB_PATH)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    ensure_schema(conn)
+    return conn
+
+
+@contextmanager
+def get_conn(db_path: Optional[Path] = None) -> Iterator[sqlite3.Connection]:
+    conn = connect(db_path)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def existing_pairs(conn: sqlite3.Connection) -> set[tuple[int, int]]:
+    cur = conn.execute("SELECT psalm_x, psalm_y FROM pair_arguments")
+    return {(row[0], row[1]) for row in cur}
+
+
+def insert_pair_argument(
+    conn: sqlite3.Connection,
+    *,
+    psalm_x: int,
+    psalm_y: int,
+    prompt: str,
+    response_text: str,
+    response_json: dict,
+    model: str,
+) -> int:
+    cur = conn.execute(
+        """
+        INSERT OR IGNORE INTO pair_arguments
+            (psalm_x, psalm_y, prompt, response_text, response_json, model, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            psalm_x,
+            psalm_y,
+            prompt,
+            response_text,
+            json.dumps(response_json, ensure_ascii=False),
+            model,
+            datetime.utcnow().isoformat(timespec="seconds"),
+        ),
+    )
+    conn.commit()
+    if cur.lastrowid:
+        return cur.lastrowid
+    # fetch id if already existed
+    cur = conn.execute(
+        "SELECT id FROM pair_arguments WHERE psalm_x = ? AND psalm_y = ?",
+        (psalm_x, psalm_y),
+    )
+    row = cur.fetchone()
+    if row is None:
+        raise RuntimeError("Failed to persist pair argument and could not recover existing ID")
+    return int(row[0])
+
+
+def pending_pairs(conn: sqlite3.Connection, limit: int) -> list[tuple[int, int]]:
+    completed = existing_pairs(conn)
+    pairs: list[tuple[int, int]] = []
+    for x in range(1, 151):
+        for y in range(1, 151):
+            if x == y:
+                continue
+            pair = (x, y)
+            if pair in completed:
+                continue
+            pairs.append(pair)
+            if len(pairs) >= limit:
+                return pairs
+    return pairs
+
+
+def pending_evaluations(conn: sqlite3.Connection, limit: int) -> list[sqlite3.Row]:
+    cur = conn.execute(
+        """
+        SELECT pa.*
+        FROM pair_arguments pa
+        LEFT JOIN pair_evaluations pe ON pe.pair_id = pa.id
+        WHERE pe.id IS NULL
+        ORDER BY pa.id ASC
+        LIMIT ?
+        """,
+        (limit,),
+    )
+    return list(cur)
+
+
+def insert_evaluation(
+    conn: sqlite3.Connection,
+    *,
+    pair_id: int,
+    score: float,
+    justification: str,
+    evaluator_model: str,
+    evaluation_json: dict,
+) -> int:
+    cur = conn.execute(
+        """
+        INSERT OR REPLACE INTO pair_evaluations
+            (pair_id, score, justification, evaluator_model, evaluation_json, created_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            pair_id,
+            score,
+            justification,
+            evaluator_model,
+            json.dumps(evaluation_json, ensure_ascii=False),
+            datetime.utcnow().isoformat(timespec="seconds"),
+        ),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def counts(conn: sqlite3.Connection) -> dict[str, int]:
+    cur = conn.execute("SELECT COUNT(*) FROM pair_arguments")
+    generated = int(cur.fetchone()[0])
+    cur = conn.execute("SELECT COUNT(*) FROM pair_evaluations")
+    evaluated = int(cur.fetchone()[0])
+    total_pairs = 150 * 149
+    return {"generated": generated, "evaluated": evaluated, "total_pairs": total_pairs}
+
+
+def recent_arguments(conn: sqlite3.Connection, limit: int = 20) -> list[sqlite3.Row]:
+    cur = conn.execute(
+        """
+        SELECT pa.id, pa.psalm_x, pa.psalm_y, pa.response_text, pa.created_at,
+               pe.score, pe.justification, pe.created_at AS evaluated_at
+        FROM pair_arguments pa
+        LEFT JOIN pair_evaluations pe ON pe.pair_id = pa.id
+        ORDER BY pa.id DESC
+        LIMIT ?
+        """,
+        (limit,),
+    )
+    return list(cur)

--- a/psalm_pairs/evaluate_pairs.py
+++ b/psalm_pairs/evaluate_pairs.py
@@ -1,0 +1,130 @@
+"""Evaluate Psalm pair arguments and record scores."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from typing import Any, Dict
+
+from . import DB_PATH
+from .db import connect, insert_evaluation, pending_evaluations
+from .openai_client import build_client, response_to_dict
+
+DEFAULT_LIMIT = 50
+EVALUATOR_MODEL = os.environ.get("PSALM_PAIRS_EVAL_MODEL", "gpt-5")
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "submit_evaluation",
+            "description": "Record a numeric quality score (0-10) for the provided Psalm pair argument along with an explanation.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "score": {
+                        "type": "number",
+                        "minimum": 0,
+                        "maximum": 10,
+                        "description": "Numeric score between 0 (very weak) and 10 (very strong).",
+                    },
+                    "justification": {
+                        "type": "string",
+                        "description": "Short explanation for the chosen score.",
+                    },
+                },
+                "required": ["score", "justification"],
+            },
+        },
+    }
+]
+
+PROMPT = """You are assessing the quality of an argument explaining why Psalm {psalm_y} follows Psalm {psalm_x}."""  # noqa: E501
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_input(argument: str, psalm_x: int, psalm_y: int) -> str:
+    return (
+        PROMPT.format(psalm_x=psalm_x, psalm_y=psalm_y)
+        + "\n\nArgument:\n"
+        + argument
+        + "\n\nProvide your assessment via the submit_evaluation tool."
+    )
+
+
+def parse_tool_call(response_dict: Dict[str, Any]) -> Dict[str, Any]:
+    for item in response_dict.get("output", []):
+        if item.get("type") != "tool_call":
+            continue
+        tool_call = item.get("tool_call", {})
+        if tool_call.get("name") != "submit_evaluation":
+            continue
+        arguments = tool_call.get("arguments")
+        if isinstance(arguments, str):
+            return json.loads(arguments)
+        if isinstance(arguments, dict):
+            return arguments
+    raise RuntimeError("No submit_evaluation tool call found in response")
+
+
+def evaluate_pair(client, row, model: str):
+    argument = row["response_text"]
+    psalm_x = row["psalm_x"]
+    psalm_y = row["psalm_y"]
+    logger.info("Evaluating argument %s (%s -> %s)", row["id"], psalm_x, psalm_y)
+    response = client.responses.create(
+        model=model,
+        input=build_input(argument, psalm_x, psalm_y),
+        reasoning={"effort": "medium"},
+        tools=TOOLS,
+        tool_choice={"type": "function", "function": {"name": "submit_evaluation"}},
+    )
+    response_dict = response_to_dict(response)
+    tool_payload = parse_tool_call(response_dict)
+    score = float(tool_payload["score"])
+    justification = str(tool_payload["justification"])
+    return response, score, justification
+
+
+def run(limit: int, model: str = EVALUATOR_MODEL) -> int:
+    with connect(DB_PATH) as conn:
+        rows = pending_evaluations(conn, limit)
+        if not rows:
+            logger.info("No pending evaluations.")
+            return 0
+        completed = 0
+        client = build_client()
+        for row in rows:
+            response, score, justification = evaluate_pair(client, row, model)
+            insert_evaluation(
+                conn,
+                pair_id=row["id"],
+                score=score,
+                justification=justification,
+                evaluator_model=model,
+                evaluation_json=response_to_dict(response),
+            )
+            completed += 1
+        return completed
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT, help="Number of arguments to evaluate")
+    parser.add_argument("--model", type=str, default=EVALUATOR_MODEL, help="Model name to use for evaluation")
+    parser.add_argument("--quiet", action="store_true", help="Reduce logging output")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=logging.INFO if not args.quiet else logging.WARNING)
+    completed = run(limit=args.limit, model=args.model)
+    logger.info("Evaluated %s arguments", completed)
+
+
+if __name__ == "__main__":
+    main()

--- a/psalm_pairs/generate_pairs.py
+++ b/psalm_pairs/generate_pairs.py
@@ -1,0 +1,82 @@
+"""Generate Psalm pair arguments using the OpenAI Responses API."""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+
+from . import DB_PATH
+from .db import connect, insert_pair_argument, pending_pairs
+from .openai_client import build_client, response_to_dict
+from .psalms import format_psalm
+
+DEFAULT_LIMIT = 50
+DEFAULT_MODEL = os.environ.get("PSALM_PAIRS_MODEL", "gpt-5")
+
+PROMPT_TEMPLATE = """Consider Psalm {x} and Psalm {y} (reproduced below). What arguments could you make to justify that Psalm {y} follows on from Psalm {x}? Consider stylistic similarities, similarities of vocab or ideas, connections to sequences of events common in ancient Israel life, mythology or history. Answer in English.\n\nPsalm {x}:\n{psalm_x}\n\nPsalm {y}:\n{psalm_y}\n"""
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_prompt(psalm_x: int, psalm_y: int) -> str:
+    return PROMPT_TEMPLATE.format(
+        x=psalm_x,
+        y=psalm_y,
+        psalm_x=format_psalm(psalm_x),
+        psalm_y=format_psalm(psalm_y),
+    )
+
+
+def generate_pair(client, psalm_x: int, psalm_y: int, model: str):
+    prompt = build_prompt(psalm_x, psalm_y)
+    logger.info("Requesting argument for Psalms %s -> %s", psalm_x, psalm_y)
+    response = client.responses.create(
+        model=model,
+        input=prompt,
+        reasoning={"effort": "high"},
+        text={"verbosity": "medium"},
+    )
+    return prompt, response
+
+
+def run(limit: int, model: str = DEFAULT_MODEL) -> int:
+    with connect(DB_PATH) as conn:
+        todo = pending_pairs(conn, limit)
+        if not todo:
+            logger.info("No remaining Psalm pairs to generate.")
+            return 0
+        created = 0
+        client = build_client()
+        for psalm_x, psalm_y in todo:
+            prompt, response = generate_pair(client, psalm_x, psalm_y, model)
+            insert_pair_argument(
+                conn,
+                psalm_x=psalm_x,
+                psalm_y=psalm_y,
+                prompt=prompt,
+                response_text=getattr(response, "output_text", ""),
+                response_json=response_to_dict(response),
+                model=model,
+            )
+            created += 1
+        return created
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--limit", type=int, default=DEFAULT_LIMIT, help="Number of pairs to generate")
+    parser.add_argument("--model", type=str, default=DEFAULT_MODEL, help="Model name to use")
+    parser.add_argument("--quiet", action="store_true", help="Reduce logging output")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    logging.basicConfig(level=logging.INFO if not args.quiet else logging.WARNING)
+    created = run(limit=args.limit, model=args.model)
+    logger.info("Generated %s pair arguments", created)
+
+
+if __name__ == "__main__":
+    main()

--- a/psalm_pairs/openai_client.py
+++ b/psalm_pairs/openai_client.py
@@ -1,0 +1,44 @@
+"""Utility helpers for talking to the OpenAI Responses API."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from openai import OpenAI
+
+OPENAI_KEY_PATH = Path.home() / ".openai.key"
+
+
+def load_api_key() -> str:
+    key = os.environ.get("OPENAI_API_KEY")
+    if key:
+        return key
+    if not OPENAI_KEY_PATH.exists():
+        raise FileNotFoundError(
+            f"Expected to find OpenAI API key at {OPENAI_KEY_PATH}. Set OPENAI_API_KEY or create the file."
+        )
+    key = OPENAI_KEY_PATH.read_text(encoding="utf-8").strip()
+    if not key:
+        raise RuntimeError(f"{OPENAI_KEY_PATH} is empty")
+    os.environ["OPENAI_API_KEY"] = key
+    return key
+
+
+def build_client() -> OpenAI:
+    load_api_key()
+    return OpenAI()
+
+
+def response_to_dict(response: Any) -> Dict[str, Any]:
+    """Return a JSON-serialisable payload for the response."""
+    if hasattr(response, "model_dump"):
+        return response.model_dump()
+    if hasattr(response, "to_dict"):
+        return response.to_dict()
+    # Fallback: try JSON dumps
+    try:
+        return json.loads(response.model_dump_json())  # type: ignore[attr-defined]
+    except Exception as exc:  # pragma: no cover - last resort
+        raise RuntimeError("Could not serialise OpenAI response") from exc

--- a/psalm_pairs/psalms.py
+++ b/psalm_pairs/psalms.py
@@ -1,0 +1,39 @@
+"""Helpers for loading Psalm JSON data and formatting prompts."""
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from . import PROJECT_ROOT
+
+PSALM_DIR = PROJECT_ROOT / "psalms_json"
+
+
+@lru_cache(maxsize=None)
+def load_psalm(psalm_number: int) -> dict:
+    path = PSALM_DIR / f"psalm_{psalm_number:03d}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"Could not find {path}")
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def format_psalm(psalm_number: int) -> str:
+    data = load_psalm(psalm_number)
+    lines = [f"Psalm {psalm_number}"]
+    for verse in data.get("verses", []):
+        vnum = verse.get("v")
+        text = verse.get("text_he", "")
+        lines.append(f"{vnum}. {text}")
+    return "\n".join(lines)
+
+
+def all_psalm_numbers() -> list[int]:
+    files = sorted(PSALM_DIR.glob("psalm_*.json"))
+    numbers: list[int] = []
+    for path in files:
+        try:
+            num = int(path.stem.split("_")[1])
+            numbers.append(num)
+        except (IndexError, ValueError):
+            continue
+    return sorted(numbers)

--- a/psalm_pairs/website.py
+++ b/psalm_pairs/website.py
@@ -1,0 +1,137 @@
+"""Generate a static HTML summary of Psalm pair progress."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import html
+from pathlib import Path
+from typing import Iterable
+
+from . import PROJECT_ROOT
+from .db import connect, counts, recent_arguments
+
+DEFAULT_OUTPUT_DIR = PROJECT_ROOT / "site"
+
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <title>Psalm Pair Arguments</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; background: #f8f9fa; color: #111; }
+    header { margin-bottom: 2rem; }
+    .stats { display: flex; flex-wrap: wrap; gap: 1rem; }
+    .card { background: white; border-radius: 8px; padding: 1rem 1.5rem; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+    table { width: 100%; border-collapse: collapse; margin-top: 2rem; }
+    th, td { padding: 0.5rem; border-bottom: 1px solid #ddd; text-align: left; }
+    th { background: #eef2f7; }
+    footer { margin-top: 3rem; font-size: 0.9rem; color: #555; }
+  </style>
+</head>
+<body>
+<header>
+  <h1>Psalm Pair Arguments</h1>
+  <p>Progress report generated on {generated_at} UTC.</p>
+</header>
+<section class=\"stats\">
+  <div class=\"card\">
+    <strong>{generated}</strong><br>Pairs generated
+  </div>
+  <div class=\"card\">
+    <strong>{evaluated}</strong><br>Pairs evaluated
+  </div>
+  <div class=\"card\">
+    <strong>{total_pairs}</strong><br>Total possible pairs
+  </div>
+  <div class=\"card\">
+    <strong>{progress:.2f}%</strong><br>Generation complete
+  </div>
+  <div class=\"card\">
+    <strong>{evaluation_progress:.2f}%</strong><br>Evaluations complete
+  </div>
+</section>
+<section>
+  <h2>Most recent arguments</h2>
+  <table>
+    <thead>
+      <tr><th>ID</th><th>Pair</th><th>Generated</th><th>Evaluation</th><th>Excerpt</th></tr>
+    </thead>
+    <tbody>
+      {rows}
+    </tbody>
+  </table>
+</section>
+<footer>
+  <p>This project explores narrative continuity within the Psalter by comparing every ordered pair of psalms.</p>
+</footer>
+</body>
+</html>
+"""
+
+
+ROW_TEMPLATE = "<tr><td>{id}</td><td>{pair}</td><td>{created}</td><td>{evaluation}</td><td>{excerpt}</td></tr>"
+
+
+def format_row(row) -> str:
+    excerpt = ""
+    if row["response_text"]:
+        first_line = row["response_text"].strip().splitlines()[0]
+        excerpt = html.escape(first_line[:160])
+    evaluation = (
+        f"Score {row['score']} on {row['evaluated_at']}" if row["score"] is not None else "Pending"
+    )
+    return ROW_TEMPLATE.format(
+        id=row["id"],
+        pair=f"{row['psalm_x']} → {row['psalm_y']}",
+        created=row["created_at"],
+        evaluation=html.escape(evaluation),
+        excerpt=excerpt,
+    )
+
+
+def render_html(stats: dict, rows: Iterable[str]) -> str:
+    generated_at = dt.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+    generated = stats["generated"]
+    evaluated = stats["evaluated"]
+    total_pairs = stats["total_pairs"]
+    progress = 100 * generated / total_pairs if total_pairs else 0
+    evaluation_progress = 100 * evaluated / total_pairs if total_pairs else 0
+    return HTML_TEMPLATE.format(
+        generated_at=generated_at,
+        generated=generated,
+        evaluated=evaluated,
+        total_pairs=total_pairs,
+        progress=progress,
+        evaluation_progress=evaluation_progress,
+        rows="\n      ".join(rows),
+    )
+
+
+def write_site(output_dir: Path = DEFAULT_OUTPUT_DIR) -> Path:
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    index_path = output_dir / "index.html"
+    with connect() as conn:
+        stats = counts(conn)
+        recent = recent_arguments(conn, limit=50)
+    rows = [format_row(row) for row in recent]
+    html_text = render_html(stats, rows)
+    index_path.write_text(html_text, encoding="utf-8")
+    return index_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT_DIR, help="Directory for the generated site")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    path = write_site(args.output)
+    print(f"Wrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,4 +6,5 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "requests>=2.32.5",
+    "openai>=1.0.0",
 ]


### PR DESCRIPTION
## Summary
- add a sqlite-backed pipeline for generating psalm pair arguments via the OpenAI Responses API
- add an evaluator that scores pending arguments through a forced tool call and record the results
- generate and deploy a static progress website from the cron script and document the configuration knobs

## Testing
- python -m compileall psalm_pairs

------
https://chatgpt.com/codex/tasks/task_e_68d8edc2dc9483258575e757d921f21d