### PR TITLE
Support running CLI scripts as standalone modules

### DIFF
--- a/psalm_pairs/evaluate_pairs.py
+++ b/psalm_pairs/evaluate_pairs.py
@@ -5,11 +5,19 @@ import argparse
 import json
 import logging
 import os
+import sys
+from pathlib import Path
 from typing import Any, Dict
 
-from . import DB_PATH
-from .db import connect, insert_evaluation, pending_evaluations
-from .openai_client import build_client, response_to_dict
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from psalm_pairs import DB_PATH
+    from psalm_pairs.db import connect, insert_evaluation, pending_evaluations
+    from psalm_pairs.openai_client import build_client, response_to_dict
+else:
+    from . import DB_PATH
+    from .db import connect, insert_evaluation, pending_evaluations
+    from .openai_client import build_client, response_to_dict
 
 DEFAULT_LIMIT = 50
 EVALUATOR_MODEL = os.environ.get("PSALM_PAIRS_EVAL_MODEL", "gpt-5")

--- a/psalm_pairs/generate_pairs.py
+++ b/psalm_pairs/generate_pairs.py
@@ -4,11 +4,20 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import sys
+from pathlib import Path
 
-from . import DB_PATH
-from .db import connect, insert_pair_argument, pending_pairs
-from .openai_client import build_client, response_to_dict
-from .psalms import format_psalm
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from psalm_pairs import DB_PATH
+    from psalm_pairs.db import connect, insert_pair_argument, pending_pairs
+    from psalm_pairs.openai_client import build_client, response_to_dict
+    from psalm_pairs.psalms import format_psalm
+else:
+    from . import DB_PATH
+    from .db import connect, insert_pair_argument, pending_pairs
+    from .openai_client import build_client, response_to_dict
+    from .psalms import format_psalm
 
 DEFAULT_LIMIT = 50
 DEFAULT_MODEL = os.environ.get("PSALM_PAIRS_MODEL", "gpt-5")

--- a/psalm_pairs/website.py
+++ b/psalm_pairs/website.py
@@ -4,11 +4,17 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import html
+import sys
 from pathlib import Path
 from typing import Iterable
 
-from . import PROJECT_ROOT
-from .db import connect, counts, recent_arguments
+if __package__ in {None, ""}:
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from psalm_pairs import PROJECT_ROOT
+    from psalm_pairs.db import connect, counts, recent_arguments
+else:
+    from . import PROJECT_ROOT
+    from .db import connect, counts, recent_arguments
 
 DEFAULT_OUTPUT_DIR = PROJECT_ROOT / "site"
 


### PR DESCRIPTION
## Summary
- ensure the CLI scripts adjust sys.path when executed directly so their imports resolve
- fall back to absolute psalm_pairs imports when launched via the file path

## Testing
- python psalm_pairs/generate_pairs.py --help *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_68d9b054899c832587de88cabbe05d15