### PR TITLE
Document uv usage and configure Claude review model

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -53,5 +53,5 @@ jobs:
           
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/sdk#command-line for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--model sonnet --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 

--- a/README.md
+++ b/README.md
@@ -48,3 +48,5 @@ Useful environment variables:
 - `REMOTE_TARGET` – `scp` destination for deployment; leave blank to skip copying
 
 The scripts expect an OpenAI API key at `~/.openai.key`.
+
+All Python entry points are run via [`uv`](https://docs.astral.sh/uv/) (for example, `uv run psalm_pairs/generate_pairs.py`).


### PR DESCRIPTION
## Summary
- note in the README that project Python scripts are executed with uv
- configure the Claude code review workflow to request the sonnet model

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b1a76a5c8325a345bdf9b87a59d0