### PR TITLE
Track and expose token usage statistics

### DIFF
--- a/psalm_pairs/db.py
+++ b/psalm_pairs/db.py
@@ -19,6 +19,9 @@ CREATE TABLE IF NOT EXISTS pair_arguments (
     response_text TEXT NOT NULL,
     response_json TEXT NOT NULL,
     model TEXT NOT NULL,
+    total_tokens INTEGER,
+    reasoning_tokens INTEGER,
+    non_reasoning_tokens INTEGER,
     created_at TEXT NOT NULL,
     UNIQUE (psalm_x, psalm_y)
 );
@@ -30,6 +33,9 @@ CREATE TABLE IF NOT EXISTS pair_evaluations (
     justification TEXT NOT NULL,
     evaluator_model TEXT NOT NULL,
     evaluation_json TEXT NOT NULL,
+    total_tokens INTEGER,
+    reasoning_tokens INTEGER,
+    non_reasoning_tokens INTEGER,
     created_at TEXT NOT NULL,
     FOREIGN KEY(pair_id) REFERENCES pair_arguments(id) ON DELETE CASCADE,
     UNIQUE (pair_id)
@@ -39,7 +45,20 @@ CREATE TABLE IF NOT EXISTS pair_evaluations (
 
 def ensure_schema(conn: sqlite3.Connection) -> None:
     conn.executescript(SCHEMA)
+    ensure_column(conn, "pair_arguments", "total_tokens", "INTEGER")
+    ensure_column(conn, "pair_arguments", "reasoning_tokens", "INTEGER")
+    ensure_column(conn, "pair_arguments", "non_reasoning_tokens", "INTEGER")
+    ensure_column(conn, "pair_evaluations", "total_tokens", "INTEGER")
+    ensure_column(conn, "pair_evaluations", "reasoning_tokens", "INTEGER")
+    ensure_column(conn, "pair_evaluations", "non_reasoning_tokens", "INTEGER")
     conn.commit()
+
+
+def ensure_column(conn: sqlite3.Connection, table: str, column: str, definition: str) -> None:
+    cur = conn.execute(f"PRAGMA table_info({table})")
+    if any(row[1] == column for row in cur):
+        return
+    conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {definition}")
 
 
 def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
@@ -74,12 +93,16 @@ def insert_pair_argument(
     response_text: str,
     response_json: dict,
     model: str,
+    total_tokens: Optional[int] = None,
+    reasoning_tokens: Optional[int] = None,
+    non_reasoning_tokens: Optional[int] = None,
 ) -> int:
     cur = conn.execute(
         """
         INSERT OR IGNORE INTO pair_arguments
-            (psalm_x, psalm_y, prompt, response_text, response_json, model, created_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+            (psalm_x, psalm_y, prompt, response_text, response_json, model,
+             total_tokens, reasoning_tokens, non_reasoning_tokens, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             psalm_x,
@@ -88,6 +111,9 @@ def insert_pair_argument(
             response_text,
             json.dumps(response_json, ensure_ascii=False),
             model,
+            total_tokens,
+            reasoning_tokens,
+            non_reasoning_tokens,
             datetime.utcnow().isoformat(timespec="seconds"),
         ),
     )
@@ -102,6 +128,19 @@ def insert_pair_argument(
     row = cur.fetchone()
     if row is None:
         raise RuntimeError("Failed to persist pair argument and could not recover existing ID")
+    if any(value is not None for value in (total_tokens, reasoning_tokens, non_reasoning_tokens)):
+        conn.execute(
+            """
+            UPDATE pair_arguments
+            SET
+                total_tokens = COALESCE(?, total_tokens),
+                reasoning_tokens = COALESCE(?, reasoning_tokens),
+                non_reasoning_tokens = COALESCE(?, non_reasoning_tokens)
+            WHERE psalm_x = ? AND psalm_y = ?
+            """,
+            (total_tokens, reasoning_tokens, non_reasoning_tokens, psalm_x, psalm_y),
+        )
+        conn.commit()
     return int(row[0])
 
 
@@ -144,12 +183,16 @@ def insert_evaluation(
     justification: str,
     evaluator_model: str,
     evaluation_json: dict,
+    total_tokens: Optional[int] = None,
+    reasoning_tokens: Optional[int] = None,
+    non_reasoning_tokens: Optional[int] = None,
 ) -> int:
     cur = conn.execute(
         """
         INSERT OR REPLACE INTO pair_evaluations
-            (pair_id, score, justification, evaluator_model, evaluation_json, created_at)
-        VALUES (?, ?, ?, ?, ?, ?)
+            (pair_id, score, justification, evaluator_model, evaluation_json,
+             total_tokens, reasoning_tokens, non_reasoning_tokens, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             pair_id,
@@ -157,6 +200,9 @@ def insert_evaluation(
             justification,
             evaluator_model,
             json.dumps(evaluation_json, ensure_ascii=False),
+            total_tokens,
+            reasoning_tokens,
+            non_reasoning_tokens,
             datetime.utcnow().isoformat(timespec="seconds"),
         ),
     )
@@ -186,3 +232,120 @@ def recent_arguments(conn: sqlite3.Connection, limit: int = 20) -> list[sqlite3.
         (limit,),
     )
     return list(cur)
+
+
+def _aggregate_token_columns(conn: sqlite3.Connection, table: str) -> tuple[int, int, int]:
+    query = f"""
+        SELECT
+            COALESCE(SUM(total_tokens), 0) AS total,
+            COALESCE(SUM(reasoning_tokens), 0) AS reasoning,
+            COALESCE(SUM(
+                CASE
+                    WHEN non_reasoning_tokens IS NOT NULL THEN non_reasoning_tokens
+                    WHEN total_tokens IS NOT NULL THEN total_tokens - COALESCE(reasoning_tokens, 0)
+                    ELSE 0
+                END
+            ), 0) AS non_reasoning
+        FROM {table}
+    """
+    row = conn.execute(query).fetchone()
+    total = int(row[0] or 0)
+    reasoning = int(row[1] or 0)
+    non_reasoning = int(row[2] or 0)
+    return total, reasoning, non_reasoning
+
+
+def token_usage_stats(conn: sqlite3.Connection) -> dict:
+    generation_total, generation_reasoning, generation_non_reasoning = _aggregate_token_columns(
+        conn, "pair_arguments"
+    )
+    evaluation_total, evaluation_reasoning, evaluation_non_reasoning = _aggregate_token_columns(
+        conn, "pair_evaluations"
+    )
+
+    overall_total = generation_total + evaluation_total
+    overall_reasoning = generation_reasoning + evaluation_reasoning
+    overall_non_reasoning = generation_non_reasoning + evaluation_non_reasoning
+
+    daily_rows = conn.execute(
+        """
+        SELECT
+            day,
+            SUM(generation_total) AS generation_total,
+            SUM(evaluation_total) AS evaluation_total,
+            SUM(generation_reasoning) AS generation_reasoning,
+            SUM(evaluation_reasoning) AS evaluation_reasoning,
+            SUM(generation_non_reasoning) AS generation_non_reasoning,
+            SUM(evaluation_non_reasoning) AS evaluation_non_reasoning
+        FROM (
+            SELECT
+                DATE(created_at) AS day,
+                COALESCE(total_tokens, 0) AS generation_total,
+                0 AS evaluation_total,
+                COALESCE(reasoning_tokens, 0) AS generation_reasoning,
+                0 AS evaluation_reasoning,
+                COALESCE(
+                    CASE
+                        WHEN non_reasoning_tokens IS NOT NULL THEN non_reasoning_tokens
+                        WHEN total_tokens IS NOT NULL THEN total_tokens - COALESCE(reasoning_tokens, 0)
+                        ELSE 0
+                    END,
+                    0
+                ) AS generation_non_reasoning,
+                0 AS evaluation_non_reasoning
+            FROM pair_arguments
+            UNION ALL
+            SELECT
+                DATE(created_at) AS day,
+                0 AS generation_total,
+                COALESCE(total_tokens, 0) AS evaluation_total,
+                0 AS generation_reasoning,
+                COALESCE(reasoning_tokens, 0) AS evaluation_reasoning,
+                0 AS generation_non_reasoning,
+                COALESCE(
+                    CASE
+                        WHEN non_reasoning_tokens IS NOT NULL THEN non_reasoning_tokens
+                        WHEN total_tokens IS NOT NULL THEN total_tokens - COALESCE(reasoning_tokens, 0)
+                        ELSE 0
+                    END,
+                    0
+                ) AS evaluation_non_reasoning
+            FROM pair_evaluations
+        )
+        GROUP BY day
+        ORDER BY day ASC
+        """
+    ).fetchall()
+
+    daily = []
+    for row in daily_rows:
+        day = row["day"]
+        generation_total_day = int(row["generation_total"] or 0)
+        evaluation_total_day = int(row["evaluation_total"] or 0)
+        reasoning_total_day = int((row["generation_reasoning"] or 0) + (row["evaluation_reasoning"] or 0))
+        non_reasoning_total_day = int(
+            (row["generation_non_reasoning"] or 0) + (row["evaluation_non_reasoning"] or 0)
+        )
+        daily.append(
+            {
+                "day": day,
+                "generation_total": generation_total_day,
+                "evaluation_total": evaluation_total_day,
+                "total": generation_total_day + evaluation_total_day,
+                "reasoning_total": reasoning_total_day,
+                "non_reasoning_total": non_reasoning_total_day,
+            }
+        )
+
+    return {
+        "generation_total": generation_total,
+        "generation_reasoning": generation_reasoning,
+        "generation_non_reasoning": generation_non_reasoning,
+        "evaluation_total": evaluation_total,
+        "evaluation_reasoning": evaluation_reasoning,
+        "evaluation_non_reasoning": evaluation_non_reasoning,
+        "overall_total": overall_total,
+        "overall_reasoning": overall_reasoning,
+        "overall_non_reasoning": overall_non_reasoning,
+        "daily": daily,
+    }

--- a/psalm_pairs/evaluate_pairs.py
+++ b/psalm_pairs/evaluate_pairs.py
@@ -13,11 +13,11 @@ if __package__ in {None, ""}:
     sys.path.append(str(Path(__file__).resolve().parent.parent))
     from psalm_pairs import DB_PATH
     from psalm_pairs.db import connect, insert_evaluation, pending_evaluations
-    from psalm_pairs.openai_client import build_client, response_to_dict
+    from psalm_pairs.openai_client import build_client, extract_usage_tokens, response_to_dict
 else:
     from . import DB_PATH
     from .db import connect, insert_evaluation, pending_evaluations
-    from .openai_client import build_client, response_to_dict
+    from .openai_client import build_client, extract_usage_tokens, response_to_dict
 
 DEFAULT_LIMIT = 50
 EVALUATOR_MODEL = os.environ.get("PSALM_PAIRS_EVAL_MODEL", "gpt-5")
@@ -91,10 +91,11 @@ def evaluate_pair(client, row, model: str):
         tool_choice={"type": "function", "function": {"name": "submit_evaluation"}},
     )
     response_dict = response_to_dict(response)
+    usage = extract_usage_tokens(response_dict)
     tool_payload = parse_tool_call(response_dict)
     score = float(tool_payload["score"])
     justification = str(tool_payload["justification"])
-    return response, score, justification
+    return response_dict, usage, score, justification
 
 
 def run(limit: int, model: str = EVALUATOR_MODEL) -> int:
@@ -106,14 +107,17 @@ def run(limit: int, model: str = EVALUATOR_MODEL) -> int:
         completed = 0
         client = build_client()
         for row in rows:
-            response, score, justification = evaluate_pair(client, row, model)
+            response_dict, usage, score, justification = evaluate_pair(client, row, model)
             insert_evaluation(
                 conn,
                 pair_id=row["id"],
                 score=score,
                 justification=justification,
                 evaluator_model=model,
-                evaluation_json=response_to_dict(response),
+                evaluation_json=response_dict,
+                total_tokens=usage["total_tokens"],
+                reasoning_tokens=usage["reasoning_tokens"],
+                non_reasoning_tokens=usage["non_reasoning_tokens"],
             )
             completed += 1
         return completed

--- a/psalm_pairs/openai_client.py
+++ b/psalm_pairs/openai_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from openai import OpenAI
 
@@ -42,3 +42,49 @@ def response_to_dict(response: Any) -> Dict[str, Any]:
         return json.loads(response.model_dump_json())  # type: ignore[attr-defined]
     except Exception as exc:  # pragma: no cover - last resort
         raise RuntimeError("Could not serialise OpenAI response") from exc
+
+
+def _coerce_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def extract_usage_tokens(response_dict: Dict[str, Any]) -> Dict[str, Optional[int]]:
+    """Extract token accounting from a response payload.
+
+    The Responses API has evolved a few times, so we defensively look for a
+    couple of different field names when determining reasoning/non-reasoning
+    token counts.
+    """
+
+    usage = response_dict.get("usage") or {}
+    output_details = usage.get("output_tokens_details") or {}
+
+    total_tokens = _coerce_int(
+        usage.get("total_tokens")
+        or usage.get("output_tokens")
+        or usage.get("completion_tokens")
+    )
+
+    reasoning_tokens = _coerce_int(
+        output_details.get("reasoning_tokens") or usage.get("reasoning_tokens")
+    )
+
+    text_tokens = _coerce_int(output_details.get("text_tokens"))
+    non_reasoning_tokens: Optional[int]
+    if text_tokens is not None:
+        non_reasoning_tokens = text_tokens
+    elif total_tokens is not None and reasoning_tokens is not None:
+        non_reasoning_tokens = max(total_tokens - reasoning_tokens, 0)
+    else:
+        non_reasoning_tokens = _coerce_int(output_details.get("non_reasoning_tokens"))
+
+    return {
+        "total_tokens": total_tokens,
+        "reasoning_tokens": reasoning_tokens,
+        "non_reasoning_tokens": non_reasoning_tokens,
+    }


### PR DESCRIPTION
## Summary
- add token usage columns and aggregation helpers in the SQLite schema
- persist reasoning/non-reasoning token counts from OpenAI responses for generation and evaluation
- extend the static site with overall token stats and a detailed token usage page with daily totals

## Testing
- python -m psalm_pairs.website --output /tmp/site

------
https://chatgpt.com/codex/tasks/task_e_68d9ccd8e7c4832583f7892205a96129