### PR TITLE
Handle function_call responses in evaluation parser

### DIFF
--- a/psalm_pairs/evaluate_pairs.py
+++ b/psalm_pairs/evaluate_pairs.py
@@ -63,11 +63,18 @@ def build_input(argument: str, psalm_x: int, psalm_y: int) -> str:
 
 def parse_tool_call(response_dict: Dict[str, Any]) -> Dict[str, Any]:
     for item in response_dict.get("output", []):
-        if item.get("type") != "tool_call":
+        item_type = item.get("type")
+        if item_type not in {"tool_call", "function_call"}:
             continue
-        tool_call = item.get("tool_call", {})
+
+        if item_type == "tool_call":
+            tool_call = item.get("tool_call", {})
+        else:  # function_call
+            tool_call = item
+
         if tool_call.get("name") != "submit_evaluation":
             continue
+
         arguments = tool_call.get("arguments")
         if isinstance(arguments, str):
             return json.loads(arguments)


### PR DESCRIPTION
## Summary
- update evaluation response parser to recognize both legacy `tool_call` and new `function_call` output entries
- ensure submit_evaluation payloads are decoded regardless of the response variant

## Testing
- not run (depends on remote OpenAI API interactions)


------
https://chatgpt.com/codex/tasks/task_e_68d9dfb0806c83259ea17abddd0c3e2c