### PR TITLE
Add heatmap overview page to static site

### DIFF
--- a/psalm_pairs/website.py
+++ b/psalm_pairs/website.py
@@ -51,6 +51,7 @@ HTML_TEMPLATE = """<!DOCTYPE html>
 <nav>
   <a href=\"index.html\">Overview</a>
   <a href=\"tokens.html\">Token usage</a>
+  <a href=\"heatmap.html\">Heatmap</a>
 </nav>
 <section class=\"stats\">
   <div class=\"card\">
@@ -121,6 +122,7 @@ TOKENS_TEMPLATE = """<!DOCTYPE html>
 <nav>
   <a href=\"index.html\">Overview</a>
   <a href=\"tokens.html\">Token usage</a>
+  <a href=\"heatmap.html\">Heatmap</a>
 </nav>
 <section class=\"grid\">
   <div class=\"card\">
@@ -165,6 +167,81 @@ TOKENS_TEMPLATE = """<!DOCTYPE html>
 """
 
 
+HEATMAP_TEMPLATE = """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <title>Psalm Pair Heatmap</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; margin: 2rem; background: #f8f9fa; color: #111; }}
+    header {{ margin-bottom: 1.5rem; }}
+    nav {{ margin-bottom: 1.5rem; }}
+    nav a {{ margin-right: 1rem; color: #0b7285; text-decoration: none; }}
+    nav a:hover {{ text-decoration: underline; }}
+    .legend {{ display: flex; flex-wrap: wrap; gap: 1rem; margin-bottom: 1.5rem; font-size: 0.95rem; }}
+    .legend-item {{ display: flex; align-items: center; gap: 0.5rem; }}
+    .legend-swatch {{ width: 18px; height: 18px; border-radius: 4px; border: 1px solid #adb5bd; box-shadow: inset 0 0 2px rgba(0,0,0,0.1); }}
+    .heatmap-container {{ background: white; border-radius: 8px; padding: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,0.1); overflow: auto; max-height: 75vh; }}
+    .heatmap-table {{ border-collapse: collapse; table-layout: fixed; font-size: 0.65rem; min-width: max-content; }}
+    .heatmap-table th, .heatmap-table td {{ border: 1px solid #dee2e6; padding: 0; width: 32px; height: 24px; text-align: center; }}
+    .heatmap-table thead th {{ background: #eef2f7; position: sticky; top: 0; z-index: 3; }}
+    .heatmap-table thead th:first-child {{ left: 0; z-index: 4; }}
+    .heatmap-table tbody th {{ position: sticky; left: 0; background: #f8f9fa; z-index: 2; }}
+    .heatmap-cell {{ position: relative; }}
+    .heatmap-cell a, .heatmap-cell span.cell-placeholder {{ display: block; width: 100%; height: 100%; }}
+    .heatmap-cell a {{ text-decoration: none; }}
+    .sr-only {{ position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }}
+    footer {{ margin-top: 2rem; font-size: 0.9rem; color: #555; }}
+  </style>
+</head>
+<body>
+<header>
+  <h1>Psalm Pair Heatmap</h1>
+  <p>Visual overview of generation and evaluation coverage across all ordered psalm pairs.</p>
+</header>
+<nav>
+  <a href=\"index.html\">Overview</a>
+  <a href=\"tokens.html\">Token usage</a>
+  <a href=\"heatmap.html\">Heatmap</a>
+</nav>
+<section>
+  <p>Generated {generated} of {total_pairs} possible ordered pairs ({progress:.2f}% complete) and evaluated {evaluated} pairs ({evaluation_progress:.2f}% complete).</p>
+</section>
+<section class=\"legend\">
+  <div class=\"legend-item\">
+    <span class=\"legend-swatch\" style=\"background: #ffffff;\"></span>
+    <span>Not generated</span>
+  </div>
+  <div class=\"legend-item\">
+    <span class=\"legend-swatch\" style=\"background: #adb5bd;\"></span>
+    <span>Generated, awaiting evaluation</span>
+  </div>
+  <div class=\"legend-item\">
+    <span class=\"legend-swatch\" style=\"background: #2563eb;\"></span>
+    <span>Low evaluation score (0)</span>
+  </div>
+  <div class=\"legend-item\">
+    <span class=\"legend-swatch\" style=\"background: linear-gradient(90deg, #2563eb 0%, #dc2626 100%); border: none;\"></span>
+    <span>Intermediate scores</span>
+  </div>
+  <div class=\"legend-item\">
+    <span class=\"legend-swatch\" style=\"background: #dc2626;\"></span>
+    <span>High evaluation score (10)</span>
+  </div>
+</section>
+<section class=\"heatmap-container\">
+  <table class=\"heatmap-table\">
+    {heatmap_table}
+  </table>
+</section>
+<footer>
+  <p>Click any colored cell to open the detailed argument page for that ordered pair.</p>
+</footer>
+</body>
+</html>
+"""
+
+
 PAIR_TEMPLATE = """<!DOCTYPE html>
 <html lang=\"en\">
 <head>
@@ -191,6 +268,7 @@ PAIR_TEMPLATE = """<!DOCTYPE html>
 <nav>
   <a href=\"../index.html\">Overview</a>
   <a href=\"../tokens.html\">Token usage</a>
+  <a href=\"../heatmap.html\">Heatmap</a>
 </nav>
 <main>
   <section>
@@ -233,6 +311,12 @@ PAIR_TEMPLATE = """<!DOCTYPE html>
 
 
 ROW_TEMPLATE = "<tr><td>{id}</td><td>{pair}</td><td>{created}</td><td>{evaluation}</td><td>{excerpt}</td></tr>"
+
+
+HEATMAP_LOW_SCORE_RGB = (37, 99, 235)
+HEATMAP_HIGH_SCORE_RGB = (220, 38, 38)
+HEATMAP_PENDING_COLOR = "#adb5bd"
+HEATMAP_NOT_GENERATED_COLOR = "#ffffff"
 
 
 def pair_filename(psalm_x: int, psalm_y: int) -> str:
@@ -304,6 +388,11 @@ def write_site(output_dir: Path = DEFAULT_OUTPUT_DIR) -> Path:
         daily_rows = [render_daily_row(row) for row in tokens["daily"]]
         tokens_html = render_tokens_html(tokens, daily_rows)
         tokens_path.write_text(tokens_html, encoding="utf-8")
+
+        heatmap_path = output_dir / "heatmap.html"
+        heatmap_matrix = build_heatmap_matrix(conn)
+        heatmap_html = render_heatmap_html(heatmap_matrix, stats)
+        heatmap_path.write_text(heatmap_html, encoding="utf-8")
 
         for row in pair_details(conn):
             filename = pair_filename(row["psalm_x"], row["psalm_y"])
@@ -405,6 +494,114 @@ def render_daily_row(row: dict) -> str:
         f"<td>{row['generation_total']}</td>"
         f"<td>{row['evaluation_total']}</td>"
         "</tr>"
+    )
+
+
+def _score_to_color(score: float) -> str:
+    ratio = max(0.0, min(1.0, score / 10.0))
+    channels = [
+        int(round(low + (high - low) * ratio)) for low, high in zip(HEATMAP_LOW_SCORE_RGB, HEATMAP_HIGH_SCORE_RGB)
+    ]
+    return "#{:02x}{:02x}{:02x}".format(*channels)
+
+
+def build_heatmap_matrix(conn) -> list[list[dict[str, str | None]]]:
+    query = """
+        SELECT
+            pa.psalm_x,
+            pa.psalm_y,
+            pe.score
+        FROM pair_arguments pa
+        LEFT JOIN pair_evaluations pe ON pe.pair_id = pa.id
+    """
+    data = {(row["psalm_x"], row["psalm_y"]): row["score"] for row in conn.execute(query)}
+
+    missing = object()
+    matrix: list[list[dict[str, str | None]]] = []
+    for psalm_x in range(1, 151):
+        row_cells: list[dict[str, str | None]] = []
+        for psalm_y in range(1, 151):
+            key = (psalm_x, psalm_y)
+            score = data.get(key, missing)
+            if score is missing:
+                status = "not_generated"
+                color = HEATMAP_NOT_GENERATED_COLOR
+                label = "Not generated yet"
+                url: str | None = None
+            elif score is None:
+                status = "generated"
+                color = HEATMAP_PENDING_COLOR
+                label = "Generated, awaiting evaluation"
+                url = pair_url(psalm_x, psalm_y)
+            else:
+                status = "evaluated"
+                numeric_score = float(score)
+                color = _score_to_color(numeric_score)
+                label = f"Evaluation score {numeric_score:.1f}"
+                url = pair_url(psalm_x, psalm_y)
+
+            row_cells.append(
+                {
+                    "psalm_x": psalm_x,
+                    "psalm_y": psalm_y,
+                    "status": status,
+                    "color": color,
+                    "label": label,
+                    "url": url,
+                }
+            )
+        matrix.append(row_cells)
+    return matrix
+
+
+def render_heatmap_table(matrix: list[list[dict[str, str | None]]]) -> str:
+    header_cells = "".join(f"<th scope=\"col\">{col}</th>" for col in range(1, 151))
+    header = (
+        "<thead>"
+        "<tr>"
+        "<th scope=\"col\">Psalm ↓</th>"
+        f"{header_cells}"
+        "</tr>"
+        "</thead>"
+    )
+
+    body_rows: list[str] = []
+    for psalm_x, row_cells in enumerate(matrix, start=1):
+        cell_html: list[str] = []
+        for cell in row_cells:
+            label_text = f"Psalm {cell['psalm_x']} → {cell['psalm_y']}: {cell['label']}"
+            label_attr = html.escape(label_text, quote=True)
+            label_html = html.escape(label_text)
+            style_attr = html.escape(f"background: {cell['color']};", quote=True)
+            if cell["url"]:
+                url_attr = html.escape(cell["url"], quote=True)
+                inner = f'<a href="{url_attr}" aria-label="{label_attr}" title="{label_attr}"></a>'
+            else:
+                inner = (
+                    '<span class="cell-placeholder" aria-hidden="true"></span>'
+                    f'<span class="sr-only">{label_html}</span>'
+                )
+            cell_html.append(
+                f'<td class="heatmap-cell" style="{style_attr}" aria-label="{label_attr}" title="{label_attr}">{inner}</td>'
+            )
+        body_rows.append(f'<tr><th scope="row">{psalm_x}</th>{"".join(cell_html)}</tr>')
+
+    body = "<tbody>" + "".join(body_rows) + "</tbody>"
+    return header + body
+
+
+def render_heatmap_html(matrix: list[list[dict[str, str | None]]], stats: dict) -> str:
+    total_pairs = stats.get("total_pairs", 0)
+    progress = 100 * stats.get("generated", 0) / total_pairs if total_pairs else 0.0
+    evaluation_progress = 100 * stats.get("evaluated", 0) / total_pairs if total_pairs else 0.0
+    table_html = render_heatmap_table(matrix)
+    return HEATMAP_TEMPLATE.format(
+        generated=stats.get("generated", 0),
+        evaluated=stats.get("evaluated", 0),
+        total_pairs=total_pairs,
+        progress=progress,
+        evaluation_progress=evaluation_progress,
+        heatmap_table=table_html,
     )
 
 


### PR DESCRIPTION
## Summary
- add a new heatmap navigation link to the overview, token, and pair detail pages
- render a heatmap page with legend and color-coded evaluation coverage for all ordered psalm pairs
- compute the heatmap matrix during site generation and write the new page alongside the existing outputs

## Testing
- python -m compileall psalm_pairs

------
https://chatgpt.com/codex/tasks/task_e_68d9e0da3d3083258c05c1a350ab7161