### PR TITLE
Silence rsync output in cron script

### DIFF
--- a/cronscript.sh
+++ b/cronscript.sh
@@ -20,7 +20,7 @@ uv run psalm_pairs/website.py --output "$SITE_DIR"
 
 if [ -n "$REMOTE_TARGET" ]; then
   if command -v rsync >/dev/null 2>&1; then
-    rsync -av --delete "$SITE_DIR"/ "$REMOTE_TARGET"
+    rsync -a --delete "$SITE_DIR"/ "$REMOTE_TARGET"
   else
     scp -r "$SITE_DIR"/* "$REMOTE_TARGET"
   fi


### PR DESCRIPTION
## Summary
- remove the verbose flag from the cron script's rsync command to reduce noise

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69085cc966608325864f51003939d3dc